### PR TITLE
Add static root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,6 @@ RUN mkdir -p /collectivo_app/test_extension/static/test_extension
 USER django-user
 
 # Set default command
-# TODO Change to production server
 CMD while ! nc -z collectivo-db 5432; do sleep 1; done && \
-             python manage.py migrate && \
-             python manage.py collectstatic --noinput && \
-             python manage.py runserver 0.0.0.0:8000
+    python manage.py migrate && \
+    python manage.py runserver 0.0.0.0:8000

--- a/collectivo_app/collectivo_app/settings.py
+++ b/collectivo_app/collectivo_app/settings.py
@@ -154,6 +154,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_DIR = os.path.realpath(os.path.join(BASE_DIR, 'static'))
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 
 # Default primary key field type


### PR DESCRIPTION
This PR defines a static root directory and removes static file generation from the default docker command, as it should not be run in development.