### PR TITLE
Remove data use tag

### DIFF
--- a/collectivo/members/apps.py
+++ b/collectivo/members/apps.py
@@ -56,7 +56,7 @@ def post_migrate_callback(sender, **kwargs):
     )
 
     tags = [
-        'Statutes approved', 'Public use approved', 'Data use approved',
+        'Statutes approved', 'Public use approved',
         'Founding event'
     ]
     for label in tags:

--- a/collectivo/members/serializers.py
+++ b/collectivo/members/serializers.py
@@ -255,14 +255,6 @@ field_settings = {
             'help_text': 'TEXT PENDING JULIANNA'
         },
     },
-    'data_use_approved': {
-        'permissions': ['create'],
-        'kwargs': {
-            'required': True,
-            'label': 'Data use approved',
-            'help_text': 'TEXT PENDING JULIANNA'
-        },
-    },
     'founding_event': {
         'permissions': ['create'],
         'kwargs': {
@@ -293,7 +285,7 @@ summary_fields = [
 ]
 register_tag_fields = [
     # 'statutes_approved'
-    'public_use_approved', 'data_use_approved', 'founding_event'
+    'public_use_approved', 'founding_event'
 ]
 
 
@@ -321,8 +313,6 @@ class MemberRegisterSerializer(MemberSerializer):
     # statutes_approved = serializers.BooleanField(write_only=True)
     public_use_approved = serializers.BooleanField(
         write_only=True, required=False)
-    data_use_approved = serializers.BooleanField(
-        write_only=True, required=True)
     founding_event = serializers.BooleanField(
         write_only=True, required=False)
 

--- a/collectivo/members/tests/test_members.py
+++ b/collectivo/members/tests/test_members.py
@@ -38,7 +38,6 @@ TEST_MEMBER_POST = {
     'survey_contact': '-',
     'survey_motivation': '-',
     'shares_payment_type': 'sepa',
-    'data_use_approved': True,
 }
 
 TEST_MEMBER_GET = {


### PR DESCRIPTION
This PR removes the data_use_approved tag/field since this is now handled by keycloak.