### PR TITLE
Extend user admin serializer

### DIFF
--- a/collectivo/core/serializers.py
+++ b/collectivo/core/serializers.py
@@ -94,7 +94,10 @@ class UserSerializer(serializers.ModelSerializer):
     """Serializer for users."""
 
     permission_groups = serializers.PrimaryKeyRelatedField(
-        many=True, queryset=PermissionGroup.objects.all()
+        many=True,
+        queryset=PermissionGroup.objects.all(),
+        required=False,
+        allow_null=True,
     )
 
     class Meta:
@@ -106,9 +109,11 @@ class UserSerializer(serializers.ModelSerializer):
             "first_name",
             "last_name",
             "email",
+            "password",
             "permission_groups",
         ]
         read_only_fields = ["id"]
+        extra_kwargs = {"password": {"write_only": True, "required": False}}
 
 
 class UserHistorySerializer(serializers.ModelSerializer):

--- a/collectivo/core/serializers.py
+++ b/collectivo/core/serializers.py
@@ -165,7 +165,13 @@ class UserSelfSerializer(serializers.ModelSerializer):
             "permission_groups",
         ]
         read_only_fields = ["first_name", "last_name"]
-        schema = {"fields": {"permissions": {"visible": False}}}
+        schema = {
+            "fields": {
+                "permissions": {"visible": False},
+                "first_name": {"input_type": "text"},
+                "last_name": {"input_type": "text"},
+            },
+        }
         extra_kwargs = {"password": {"write_only": True, "required": False}}
 
 

--- a/collectivo/core/serializers.py
+++ b/collectivo/core/serializers.py
@@ -126,26 +126,13 @@ class UserHistorySerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class UserProfileSerializer(serializers.ModelSerializer):
-    """Serializer for members to manage their own data."""
+class UserSelfSerializer(serializers.ModelSerializer):
+    """Serializer for members to manage their user account."""
 
-    # TODO: Display all permissions of the user based on their groups
-    # permissions = serializers.PrimaryKeyRelatedField(
-    #     many=True, queryset=Permission.objects.all()
-    # )
-    permissions = serializers.SerializerMethodField()
-
-    def get_permissions(self, obj):
-        """Return permissions of the user."""
-        perms = {}
-        for name, ext in Permission.objects.filter(
-            groups__in=obj.permission_groups.all()
-        ).values_list("name", "extension__name"):
-            if ext in perms:
-                perms[ext].append(name)
-            else:
-                perms[ext] = [name]
-        return perms
+    permission_groups = serializers.PrimaryKeyRelatedField(
+        read_only=True,
+        many=True,
+    )
 
     class Meta:
         """Serializer settings."""
@@ -156,9 +143,10 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "last_name",
             "email",
             "password",
-            "permissions",
+            "permission_groups",
         ]
         read_only_fields = ["first_name", "last_name"]
+
         extra_kwargs = {"password": {"write_only": True, "required": False}}
 
 

--- a/collectivo/core/serializers.py
+++ b/collectivo/core/serializers.py
@@ -134,6 +134,24 @@ class UserSelfSerializer(serializers.ModelSerializer):
         many=True,
     )
 
+    permissions = serializers.SerializerMethodField()
+
+    def get_permissions(self, obj):
+        """
+        Return permissions of the user.
+
+        This field is used internally to determine the permissions of the user.
+        """
+        perms = {}
+        for name, ext in Permission.objects.filter(
+            groups__in=obj.permission_groups.all()
+        ).values_list("name", "extension__name"):
+            if ext in perms:
+                perms[ext].append(name)
+            else:
+                perms[ext] = [name]
+        return perms
+
     class Meta:
         """Serializer settings."""
 
@@ -143,10 +161,11 @@ class UserSelfSerializer(serializers.ModelSerializer):
             "last_name",
             "email",
             "password",
+            "permissions",
             "permission_groups",
         ]
         read_only_fields = ["first_name", "last_name"]
-
+        schema = {"fields": {"permissions": {"visible": False}}}
         extra_kwargs = {"password": {"write_only": True, "required": False}}
 
 

--- a/collectivo/core/serializers.py
+++ b/collectivo/core/serializers.py
@@ -8,6 +8,7 @@ from django.utils.module_loading import import_string
 from rest_framework import serializers
 
 from collectivo.utils.schema import SchemaCondition
+from collectivo.utils.serializers import create_history_serializer
 
 from .models import CoreSettings, Permission, PermissionGroup
 
@@ -80,16 +81,6 @@ class PermissionGroupSerializer(serializers.ModelSerializer):
         }
 
 
-class PermissionGroupHistorySerializer(serializers.ModelSerializer):
-    """Serializer for history of permission groups."""
-
-    class Meta:
-        """Serializer settings."""
-
-        model = PermissionGroup.history.model
-        fields = "__all__"
-
-
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for users."""
 
@@ -114,16 +105,6 @@ class UserSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id"]
         extra_kwargs = {"password": {"write_only": True, "required": False}}
-
-
-class UserHistorySerializer(serializers.ModelSerializer):
-    """Serializer for history of users."""
-
-    class Meta:
-        """Serializer settings."""
-
-        model = User.history.model
-        fields = "__all__"
 
 
 class UserSelfSerializer(serializers.ModelSerializer):
@@ -249,3 +230,8 @@ class UserProfilesSerializer(serializers.ModelSerializer):
             "groups",
         ]
         read_only_fields = ["user"]
+
+
+UserHistorySerializer = create_history_serializer(User)
+PermissionHistorySerializer = create_history_serializer(Permission)
+PermissionGroupHistorySerializer = create_history_serializer(PermissionGroup)

--- a/collectivo/core/urls.py
+++ b/collectivo/core/urls.py
@@ -20,9 +20,9 @@ router.register(
 router.register("permission", views.PermissionViewSet, basename="permissions")
 router.register("groups", views.PermissionGroupViewSet, basename="groups")
 router.register(
-    "group-history",
+    "groups-history",
     views.PermissionGroupHistoryViewSet,
-    basename="group-history",
+    basename="groups-history",
 )
 
 router_dd = DirectDetailRouter()

--- a/collectivo/core/views.py
+++ b/collectivo/core/views.py
@@ -148,7 +148,7 @@ class UserProfileViewSet(
     """Viewset for django users to manage their own data."""
 
     queryset = User.objects.all()
-    serializer_class = serializers.UserProfileSerializer
+    serializer_class = serializers.UserSelfSerializer
     permission_classes = [IsAuthenticated]
 
     def get_object(self):

--- a/collectivo/dashboard/setup.py
+++ b/collectivo/dashboard/setup.py
@@ -27,17 +27,6 @@ def setup(sender, **kwargs):
         order=0,
     )
 
-    MenuItem.objects.register(
-        name="admin",
-        label="Dashboard",
-        extension=extension,
-        route=extension.name + "/admin",
-        icon_name="pi-th-large",
-        requires_perm=("admin", "core"),
-        parent="admin",
-        order=80,
-    )
-
     if settings.COLLECTIVO["example_data"]:
         DashboardTile.objects.register(
             name="welcome_tile",

--- a/collectivo/dashboard/tests.py
+++ b/collectivo/dashboard/tests.py
@@ -27,7 +27,7 @@ class DashboardSetupTests(TestCase):
     def test_menu_items_exist(self):
         """Test that the menu items are registered."""
         res = MenuItem.objects.filter(extension__name=EXTENSION_NAME)
-        self.assertEqual(len(res), 2)
+        self.assertEqual(len(res), 1)
 
 
 class DashboardPublicAPITests(TestCase):

--- a/collectivo/extensions/setup.py
+++ b/collectivo/extensions/setup.py
@@ -1,25 +1,13 @@
 """Setup function for the extensions module."""
 from collectivo.extensions.apps import ExtensionsConfig
 from collectivo.extensions.models import Extension
-from collectivo.menus.models import MenuItem
 
 
 def setup(sender, **kwargs):
     """Initialize extension after database is ready."""
 
-    extension = Extension.objects.register(
+    Extension.objects.register(
         name=ExtensionsConfig.name,
         description=ExtensionsConfig.description,
         built_in=True,
-    )
-
-    MenuItem.objects.register(
-        name="extensions",
-        label="Extensions",
-        extension=extension,
-        parent="admin",
-        route=extension.name + "/admin",
-        requires_perm=("admin", "core"),
-        icon_name="pi-box",
-        order=90,
     )

--- a/collectivo/tags/setup.py
+++ b/collectivo/tags/setup.py
@@ -14,19 +14,8 @@ User = get_user_model()
 def setup(sender, **kwargs):
     """Initialize extension after database is ready."""
 
-    extension = Extension.objects.register(
+    Extension.objects.register(
         name=TagsConfig.name, description=TagsConfig.description, built_in=True
-    )
-
-    MenuItem.objects.register(
-        name="tags_admin",
-        label="Tags",
-        extension=extension,
-        route=extension.name + "/admin",
-        icon_name="pi-tags",
-        requires_perm=("admin", "core"),
-        parent="admin",
-        order=2,
     )
 
     if settings.COLLECTIVO["example_data"]:

--- a/collectivo/tags/setup.py
+++ b/collectivo/tags/setup.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from collectivo.extensions.models import Extension
-from collectivo.menus.models import MenuItem
 
 from .apps import TagsConfig
 from .models import Tag

--- a/collectivo/tags/views.py
+++ b/collectivo/tags/views.py
@@ -2,12 +2,13 @@
 import logging
 
 from django.contrib.auth import get_user_model
-from rest_framework import mixins, viewsets
+from rest_framework import viewsets
 from rest_framework.exceptions import ValidationError
 
 from collectivo.utils.filters import get_filterset, get_ordering_fields
-from collectivo.utils.mixins import HistoryMixin, SchemaMixin
+from collectivo.utils.mixins import SchemaMixin
 from collectivo.utils.permissions import HasPerm, IsSuperuser
+from collectivo.utils.viewsets import HistoryViewSet
 
 from . import models, serializers
 
@@ -54,9 +55,7 @@ class TagViewSet(SchemaMixin, viewsets.ModelViewSet):
         return super().perform_destroy(instance)
 
 
-class TagHistoryViewSet(
-    SchemaMixin, HistoryMixin, mixins.ListModelMixin, viewsets.GenericViewSet
-):
+class TagHistoryViewSet(HistoryViewSet):
     """View history of a tag."""
 
     permission_classes = [HasPerm]


### PR DESCRIPTION
- Allow admin to set user passwords
- Add Permission Group field that is editable
- Permission field is now invisible (only used internally)
- Move extensions and dashboard into settings
- Corresponds with https://github.com/MILA-Wien/collectivo-ux/pull/101